### PR TITLE
fix(readme): Update readme for proper installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ npm install @gar/hapi-json-api
 ## Example of use
 
 ```javascript
-//where server is a hapi server
+//where server is a hapi server, for hapi 17
 
-server.register({
-    register: require('@gar/hapi-json-api')
+await server.register({
+    plugin: require('@gar/hapi-json-api'),
     options: {}
 });
 ```


### PR DESCRIPTION
Hello, just wanted to try this package out and see how it works. Using hapi@17.5.3 tried following the readme instructions to register the plugin and got the following error:

```
Invalid plugin options {
      "plugin": {
        "options": {},
...
[1] "register" must be a Function
...
```

after checking the source, i was able to register using the changes in the readme